### PR TITLE
Remove old C-style array syntax.

### DIFF
--- a/source/derelict/freeimage/types.d
+++ b/source/derelict/freeimage/types.d
@@ -114,7 +114,7 @@ alias BITMAPINFOHEADER* PBITMAPINFOHEADER;
 
 align( 1 ) struct BITMAPINFO {
     BITMAPINFOHEADER bmiHeader;
-    RGBQUAD          bmiColors[1];
+    RGBQUAD[1]       bmiColors;
 }
 
 alias BITMAPINFO* PBITMAPINFO;


### PR DESCRIPTION
Requirement to get building on master without warnings.