### PR TITLE
Make BOOL definition compatible with core.sys.windows.windows

### DIFF
--- a/source/derelict/freeimage/types.d
+++ b/source/derelict/freeimage/types.d
@@ -68,7 +68,7 @@ enum {
     SEEK_END = 2
 }
 
-alias BOOL = uint;
+alias BOOL = int;
 alias BYTE = ubyte;
 alias WORD = ushort;
 alias DWORD = c_ulong;


### PR DESCRIPTION
core.sys.windows.windows defines BOOL as int so we can't import both core.sys.windows.windows and 
derelict.freeimage.freeimage in same the same source file